### PR TITLE
Fix wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![screenshot](screenshot.png "Screenshot of www.layfla.gs")
 
-This project is a [PWA](https://developers.google.com/web/progressive-web-apps/) and works even w/o stylesheets (just the infos then) and w/o JS (no offline capabilities then).
+This project is a [PWA](https://developers.google.com/web/progressive-web-apps/) and works even w/o stylesheets (just the information then) and w/o JS (no offline capabilities then).
 
 ## Local development
 


### PR DESCRIPTION
## Summary
- update phrasing in README to say "just the information then" instead of "just the infos then"

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6887950af480832d83bb2057ef82b802